### PR TITLE
edited how the cv import service handles social media links

### DIFF
--- a/src/cv-import/cv-import.service.ts
+++ b/src/cv-import/cv-import.service.ts
@@ -17,21 +17,21 @@ export class CvImportService {
     private readonly supabaseCvImportService: SupabaseCvImportService,
     private readonly documentParserService: DocumentParserService,
     private readonly openAiAPIService: OpenAiAPIService,
-  ) {}
+  ) { }
 
   async processFiles(
     files: Express.Multer.File[],
     saveToUser: string,
   ): Promise<boolean> {
-    let dataString: string = '';
+    let dataString = '';
 
-    if (files.length > 10 || files.length == 0) {
+    if (files.length > 10 || files.length === 0) {
       console.error('1-10 files allowed, aborting');
       return false;
     }
 
     for (const file of files) {
-      if (file.buffer.length == 0) {
+      if (file.buffer.length === 0) {
         console.error('File buffer was empty on %s, ignoring', file.filename);
         continue;
       }
@@ -68,8 +68,9 @@ export class CvImportService {
       return false;
     }
 
-    const structuredJson =
-      await this.openAiAPIService.textToStructuredJSON(dataString);
+    const structuredJson = await this.openAiAPIService.textToStructuredJSON(
+      dataString,
+    );
 
     // happy path
     if (structuredJson) {
@@ -83,35 +84,43 @@ export class CvImportService {
     return false;
   }
 
-  async _saveJsonAsCv(
+  private async _saveJsonAsCv(
     json: Record<string, any>,
     user_id: string,
   ): Promise<boolean> {
     // Save a new cv to user and get a new cv id as return value
     const cv_id = await this.supabaseCvImportService.insertCv(user_id);
 
-    if (cv_id != null) {
-      await this.supabaseCvImportService.updateProfile(
-        json.profiles[0],
-        user_id,
-      );
-      await this.supabaseCvImportService.insertSkills(
-        json.skills,
-        user_id,
-        cv_id,
-      );
+    if (cv_id !== null) {
+      // Process profile data
+      const profileData = json.profiles[0];
+
+      if (
+        profileData.social_media_links &&
+        typeof profileData.social_media_links === 'string'
+      ) {
+        profileData.social_media_links = profileData.social_media_links
+          .split(',')
+          .map((link: string) => link.trim());
+      }
+
+      await this.supabaseCvImportService.updateProfile(profileData, user_id);
+
+      // Insert other CV components
+      await this.supabaseCvImportService.insertSkills(json.skills, user_id, cv_id);
       await this.supabaseCvImportService.insertCertifications(
         json.certifications,
         user_id,
         cv_id,
       );
-      const categories =
-        await this.supabaseCvImportService.insertProjectCategories(
-          json.project_categories,
-          user_id,
-          cv_id,
-        );
-      if (categories != null) {
+
+      const categories = await this.supabaseCvImportService.insertProjectCategories(
+        json.project_categories,
+        user_id,
+        cv_id,
+      );
+
+      if (categories !== null) {
         await this.supabaseCvImportService.insertProjects(
           json.projects,
           categories,


### PR DESCRIPTION
this change ensures that the links go to the database in a proper format:

proper format is ["link1", "link2"] instead of ["link1, link2"]

 
fixed a bug when importing a cv from pdf, it would only extract one link from the document

