### PR TITLE
ext-jetrotolli/par-138-bug-import-cv-doesnt-work

### DIFF
--- a/src/cv-import/schema/database-schema.ts
+++ b/src/cv-import/schema/database-schema.ts
@@ -21,12 +21,12 @@ export const databaseSchema = {
           received: {
             type: 'string',
             description:
-              'The date when the certification was received. Leave blank if the date is not given.',
+              'The date when the certification was received. Input NULL if the date is not given.',
           },
           valid_until: {
             type: 'string',
             description:
-              'The expiration date of the certification. Leave blank if the date is not given.',
+              'The expiration date of the certification. Input NULL if the date is not given.',
           },
         },
         required: ['name', 'received', 'valid_until'],
@@ -118,12 +118,12 @@ export const databaseSchema = {
             start_date: {
               type: 'string',
               description:
-                'The start date of this project category. Leave blank if the date is not given.',
+                'The start date of this project category. Input NULL if the date is not given.',
             },
             end_date: {
               type: 'string',
               description:
-                'The end date of this project category. Leave blank if the date is not given.',
+                'The end date of this project category. Input NULL if the date is not given.',
             },
             id: {
               type: 'integer',
@@ -154,12 +154,12 @@ export const databaseSchema = {
             start_date: {
               type: 'string',
               description:
-                'The date when the project started. Leave blank if the date is not given.',
+                'The date when the project started. Input NULL if the date is not given.',
             },
             end_date: {
               type: 'string',
               description:
-                'The date when the project ended. Leave blank if the date is not given.',
+                'The date when the project ended. Input NULL if the date is not given.',
             },
             role: {
               type: 'string',

--- a/src/cv-import/service/openai.service.ts
+++ b/src/cv-import/service/openai.service.ts
@@ -34,8 +34,10 @@ export class OpenAiAPIService {
 
       const response = await structuredLlm.invoke(
         `Extract and copy information exactly as it is to JSON structure from the following CV files. Do not modify or hallucinate new data under any circumstances.
-        We want to transfer all of our employee CVs to same mold which follows our company CV standard.
-        Ensure all fields are filled as accurately as possible based on the provided data. ${dataString} DATES ARE ALWAYS YYYY-MM-DD (e.g., 2020-06-21). 
+        We want to transfer all of the given CVs to same template which follows our company CV standard.
+        Ensure all fields are filled as accurately as possible reading from this data: ${dataString} 
+        If dates are found they must be in this format: YYYY-MM-DD (e.g., 2020-06-21).
+        If a required date is not found from the document input NULL instead.
         Dates are in project categories and certifications. 
         The output language should always be english and CVs imported in other languages needs to be translated.`,
         //`Fill information to JSON structure from the following CV files (fill projects and project categories always). ${dataString} DATES ARE ALLWAYS YYYY-MM-DD (eg. 2020-06-21). Dates are in project categories and certifications`,


### PR DESCRIPTION
This push will:
- Change the AI prompt for schema to instruct the AI to input NULL when clear date is absent
- Change the openAI instructions to give the AI clearer and more defined instructions on how to act when encountering a missing date.
